### PR TITLE
Update version comparison syntax

### DIFF
--- a/templates/default_passenger_virtualhost.j2
+++ b/templates/default_passenger_virtualhost.j2
@@ -13,7 +13,7 @@
   <Directory {{ passenger_deploy_dir }}/public>
     Allow from all
     Options -MultiViews
-{% if apache_version | version_compare('2.4', '>=') %}
+{% if apache_version is version('2.4', '>=') %}
     # Uncomment this if you're on Apache >= 2.4:
     Require all granted
 {% endif %}


### PR DESCRIPTION
Duplicating jhu-library-applications/catalyst-ansible#61

The syntax for doing a conditional based
on a version number has changed in ansible
2.9.x and this line will fail now.

This changes it to use the newer syntax.

See ansible/ansible#64174