### PR TITLE
Essentialy hard-code ruby interpreter path.

### DIFF
--- a/tasks/deploy_rails.yml
+++ b/tasks/deploy_rails.yml
@@ -1,31 +1,31 @@
 ---
-- name: get ruby interpreter info
-  command: "passenger-config about ruby-command"
-  register: ruby_interpreter_result
-  changed_when: false
-
-  # NOTE: when a group argument is provided, regex_search returns an array of matches,
-  # so we have to use [0] to get the first, even if there's only one
-- name: extract ruby interpreter path from result
-  set_fact: ruby_interpreter_matches={{ ruby_interpreter_result.stdout | regex_search('Command:\s+(?P<path>.*)', '\\g<path>' ) }}
-- set_fact:
-    ruby_interpreter: "{{ ruby_interpreter_matches[0] }}"
-
-- name: test ruby_interpreter
-  debug: var=ruby_interpreter
+#- name: get ruby interpreter info
+#  command: "passenger-config about ruby-command"
+#  register: ruby_interpreter_result
+#  changed_when: false
+#
+#  # NOTE: when a group argument is provided, regex_search returns an array of matches,
+#  # so we have to use [0] to get the first, even if there's only one
+#- name: extract ruby interpreter path from result
+#  set_fact: ruby_interpreter_matches={{ ruby_interpreter_result.stdout | regex_search('Command:\s+(?P<path>.*)', '\\g<path>' ) }}
+#- set_fact:
+#    ruby_interpreter: "{{ ruby_interpreter_matches[0] }}"
+#
+#- name: test ruby_interpreter
+#  debug: var=ruby_interpreter
 
 - name: get apache version info
-  command: bash -lc "{{ apache_service }} -v"
+  ansible.builtin.shell: "{{ apache_service }} -v | grep 'Apache/' | cut -d/ -f2 | awk '{print $1}'"
   register: apache_version_result
   changed_when: false
 
   # NOTE: searching a string like "Server version: Apache/2.4.6 (CentOS)""
   # NOTE: when a group argument is provided, regex_search returns an array of matches,
   # so we have to use [0] to get the first, even if there's only one
-- name: extract apache version from result
-  set_fact: apache_version_matches={{ apache_version_result.stdout | regex_search('Apache/(?P<version>\d+\.\d+)', '\\g<version>' ) }}
+#- name: extract apache version from result
+#set_fact: apache_version_matches={{ apache_version_result.stdout | regex_search('Apache/(?P<version>\d+\.\d+)', '\\g<version>' ) }}
 - set_fact:
-    apache_version: "{{ apache_version_matches[0] }}"
+    apache_version: "{{ apache_version_result.stdout }}"
 
 - name: insert passenger-specific configs into virtualhost config
   blockinfile:

--- a/templates/default_passenger_virtualhost.j2
+++ b/templates/default_passenger_virtualhost.j2
@@ -1,7 +1,7 @@
   # Tell Apache and Passenger where your app's 'public' directory is
   DocumentRoot {{ passenger_deploy_dir }}/public
 
-  PassengerRuby {{ ruby_interpreter }}
+  PassengerRuby /opt/rubies/{{ chruby_ruby_version }}/bin/ruby
   PassengerAppEnv {{ passenger_app_environment }}
   PassengerDefaultUser {{ passenger_app_user }}
   PassengerDefaultGroup {{ passenger_app_user }}


### PR DESCRIPTION
This role includes a template that sets the ruby interpreter path. This path was determined on the fly in ansible in a fragile manner -- dependent on the environment. Simplified this to make more clear. However, if it wasn't before, this role now depends on the `chruby` role being run before it.